### PR TITLE
Fix neurokit2 library is not installed issue

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -46,12 +46,12 @@ services:
       - mysql
       - redis
 
-  celery:
-    build: .
-    command: celery -A web worker -l info
-    working_dir: /code/web
-    volumes:
-      - .:/code
-    depends_on:
-      - mysql
-      - redis
+  # celery:
+  #   build: .
+  #   command: celery -A web worker -l info
+  #   working_dir: /code/web
+  #   volumes:
+  #     - .:/code
+  #   depends_on:
+  #     - mysql
+  #     - redis

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -3,3 +3,4 @@
  uwsgi
  celery
  redis
+ neurokit2


### PR DESCRIPTION
This PR resolves #1 

* Added neurokit2 library into the requirement.txt file
* Remove celery server from the Docker Compose file